### PR TITLE
Rebake posts with mentions for anonymization

### DIFF
--- a/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
+++ b/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
@@ -22,9 +22,9 @@ module DiscoursePluginAnonymizeUser
         sleep(1)
 
         # Rebake all posts where the user is mentioned to refresh excerpts
-        Post.where('raw LIKE ?', '%@#{@user.username}%').find_each do |post|
-          post.rebake!
-        end
+        Post
+          .where('raw LIKE ?', '%@#{@user.username}%')
+          .find_each { |post| post.rebake! }
         render json: success_json.merge(username: user.username)
       else
         render json: failed_json.merge(username: user.username)

--- a/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
+++ b/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
@@ -24,7 +24,7 @@ module DiscoursePluginAnonymizeUser
         # Rebake all posts where the user is mentioned to refresh excerpts
         Post
           .find_each do |post|
-            post.rebake!
+            post.raw = "test"
           end
         render json: success_json.merge(username: user.username)
       else

--- a/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
+++ b/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
@@ -20,7 +20,6 @@ module DiscoursePluginAnonymizeUser
       if user = UserAnonymizer.new(@user, current_user, opts).make_anonymous
         # Sleep 1 second, otherwise the rebake is too soon
         sleep(1)
-
         # Rebake all posts where the user is mentioned to refresh excerpts
         Post.where("raw LIKE ?", "%@#{@user.username}%").find_each do |post|
           post.rebake!

--- a/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
+++ b/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
@@ -18,10 +18,11 @@ module DiscoursePluginAnonymizeUser
       opts[:anonymize_ip] = "0.0.0.0"
 
       if user = UserAnonymizer.new(@user, current_user, opts).make_anonymous
+        sleep(1)
         # Rebake all posts of the user to refresh excerpts
-        # Post.where(user_id: @user.id).find_each do |post|
-        #   post.rebake!
-        # end
+        Post.where(user_id: @user.id).find_each do |post|
+          post.rebake!
+        end
         render json: success_json.merge(username: user.username)
       else
         render json: failed_json.merge(username: user.username)

--- a/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
+++ b/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
@@ -22,7 +22,7 @@ module DiscoursePluginAnonymizeUser
         sleep(1)
 
         # Rebake all posts where the user is mentioned to refresh excerpts
-        Post.count
+        Post.where("raw LIKE ?", "%@#{@user.username}%")
 
         render json: success_json.merge(username: user.username)
       else

--- a/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
+++ b/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
@@ -22,10 +22,10 @@ module DiscoursePluginAnonymizeUser
         sleep(1)
 
         # Rebake all posts where the user is mentioned to refresh excerpts
-        Post.find_each do |post|
-          sleep(1)
-        end
-        
+        # Post.find_each do |post|
+        #   sleep(1)
+        # end
+
         render json: success_json.merge(username: user.username)
       else
         render json: failed_json.merge(username: user.username)

--- a/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
+++ b/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
@@ -23,8 +23,10 @@ module DiscoursePluginAnonymizeUser
 
         # Rebake all posts where the user is mentioned to refresh excerpts
         Post
-          .where('raw LIKE ?', '%@#{@user.username}%')
-          .find_each { |post| post.rebake! }
+          .where("raw LIKE ?", "%@#{@user.username}%")
+          .find_each do |post|
+            post.rebake!
+          end
         render json: success_json.merge(username: user.username)
       else
         render json: failed_json.merge(username: user.username)

--- a/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
+++ b/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
@@ -18,9 +18,7 @@ module DiscoursePluginAnonymizeUser
       opts[:anonymize_ip] = "0.0.0.0"
 
       if user = UserAnonymizer.new(@user, current_user, opts).make_anonymous
-        # Sleep 1 second, otherwise the rebake is too soon
         sleep(1)
-        # Rebake all posts where the user is mentioned to refresh excerpts
         Post.where("raw LIKE ?", "%@#{@user.username}%").find_each do |post|
           post.rebake!
         end

--- a/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
+++ b/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
@@ -22,8 +22,7 @@ module DiscoursePluginAnonymizeUser
         sleep(1)
 
         # Rebake all posts where the user is mentioned to refresh excerpts
-        Post.where("raw LIKE ?", "%@#{@user.username}%").each
-        do |post|
+        Post.where("raw LIKE ?", "%@#{@user.username}%").find_each do |post|
           post.rebake!
         end
 

--- a/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
+++ b/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
@@ -22,9 +22,9 @@ module DiscoursePluginAnonymizeUser
         sleep(1)
 
         # Rebake all posts where the user is mentioned to refresh excerpts
-        # Post.where("raw LIKE ?", "%@#{@user.username}%").find_each do |post|
-        #   post.rebake!
-        # end
+        Post.where("raw LIKE ?", "%@#{user.username}%").find_each do |post|
+          post.rebake!
+        end
         render json: success_json.merge(username: user.username)
       else
         render json: failed_json.merge(username: user.username)

--- a/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
+++ b/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
@@ -21,8 +21,9 @@ module DiscoursePluginAnonymizeUser
         # Sleep 1 second, otherwise the rebake is too soon
         sleep(1)
 
-        # Rebake all posts where the user is mentioned to refresh excerpts
-        Post.where("raw LIKE ?", "%@#{@user.username}%")
+        Post.where("raw LIKE ?", "%@#{@user.username}%").find_each do |post|
+          post.rebake!
+        end
 
         render json: success_json.merge(username: user.username)
       else

--- a/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
+++ b/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
@@ -22,10 +22,8 @@ module DiscoursePluginAnonymizeUser
         sleep(1)
 
         # Rebake all posts where the user is mentioned to refresh excerpts
-        Post.find_each do |post|
-        sleep(1)
-        end
-        
+        Post.count
+
         render json: success_json.merge(username: user.username)
       else
         render json: failed_json.merge(username: user.username)

--- a/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
+++ b/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
@@ -23,7 +23,6 @@ module DiscoursePluginAnonymizeUser
 
         # Rebake all posts where the user is mentioned to refresh excerpts
         Post
-          .where("raw LIKE '%@#{@user.username}%'")
           .find_each do |post|
             post.rebake!
           end

--- a/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
+++ b/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
@@ -18,9 +18,11 @@ module DiscoursePluginAnonymizeUser
       opts[:anonymize_ip] = "0.0.0.0"
 
       if user = UserAnonymizer.new(@user, current_user, opts).make_anonymous
+        # Sleep 1 second, otherwise the rebake is too soon
         sleep(1)
-        # Rebake all posts of the user to refresh excerpts
-        Post.where(user_id: @user.id).find_each do |post|
+
+        # Rebake all posts where the user is mentioned to refresh excerpts
+        Post.where("raw LIKE ?", "%@#{@user.username}%").find_each do |post|
           post.rebake!
         end
         render json: success_json.merge(username: user.username)

--- a/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
+++ b/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
@@ -18,6 +18,10 @@ module DiscoursePluginAnonymizeUser
       opts[:anonymize_ip] = "0.0.0.0"
 
       if user = UserAnonymizer.new(@user, current_user, opts).make_anonymous
+        # Rebake all posts of the user to refresh excerpts
+        Post.where(user_id: @user.id).find_each do |post|
+          post.rebake!
+        end
         render json: success_json.merge(username: user.username)
       else
         render json: failed_json.merge(username: user.username)

--- a/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
+++ b/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
@@ -23,7 +23,7 @@ module DiscoursePluginAnonymizeUser
 
         # Rebake all posts where the user is mentioned to refresh excerpts
         Post
-          .where("raw LIKE ?", "%@#{@user.username}%")
+          .where("raw LIKE '%@#{@user.username}%'")
           .find_each do |post|
             post.rebake!
           end

--- a/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
+++ b/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
@@ -21,7 +21,8 @@ module DiscoursePluginAnonymizeUser
         # Sleep 1 second, otherwise the rebake is too soon
         sleep(1)
 
-        Post.where("raw LIKE ?", "%@#{@user.username}%").find_each do |post|
+        Post.where("raw LIKE ?", "%@#{@user.username}%").find_each 
+        do |post|
           post.rebake!
         end
 

--- a/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
+++ b/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
@@ -22,10 +22,10 @@ module DiscoursePluginAnonymizeUser
         sleep(1)
 
         # Rebake all posts where the user is mentioned to refresh excerpts
-        # Post.find_each do |post|
-        #   sleep(1)
-        # end
-
+        Post.find_each do |post|
+        sleep(1)
+        end
+        
         render json: success_json.merge(username: user.username)
       else
         render json: failed_json.merge(username: user.username)

--- a/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
+++ b/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
@@ -21,7 +21,8 @@ module DiscoursePluginAnonymizeUser
         # Sleep 1 second, otherwise the rebake is too soon
         sleep(1)
 
-        Post.where("raw LIKE ?", "%@#{@user.username}%").find_each 
+        # Rebake all posts where the user is mentioned to refresh excerpts
+        Post.where("raw LIKE ?", "%@#{@user.username}%").each
         do |post|
           post.rebake!
         end

--- a/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
+++ b/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
@@ -22,10 +22,10 @@ module DiscoursePluginAnonymizeUser
         sleep(1)
 
         # Rebake all posts where the user is mentioned to refresh excerpts
-        Post
-          .find_each do |post|
-            post.raw = "test"
-          end
+        Post.find_each do |post|
+          sleep(1)
+        end
+        
         render json: success_json.merge(username: user.username)
       else
         render json: failed_json.merge(username: user.username)

--- a/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
+++ b/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
@@ -19,9 +19,9 @@ module DiscoursePluginAnonymizeUser
 
       if user = UserAnonymizer.new(@user, current_user, opts).make_anonymous
         # Rebake all posts of the user to refresh excerpts
-        Post.where(user_id: @user.id).find_each do |post|
-          post.rebake!
-        end
+        # Post.where(user_id: @user.id).find_each do |post|
+        #   post.rebake!
+        # end
         render json: success_json.merge(username: user.username)
       else
         render json: failed_json.merge(username: user.username)

--- a/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
+++ b/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
@@ -18,10 +18,13 @@ module DiscoursePluginAnonymizeUser
       opts[:anonymize_ip] = "0.0.0.0"
 
       if user = UserAnonymizer.new(@user, current_user, opts).make_anonymous
+        # Sleep 1 second, otherwise the rebake is too soon
         sleep(1)
-        Post.where("raw LIKE ?", "%@#{@user.username}%").find_each do |post|
-          post.rebake!
-        end
+
+        # Rebake all posts where the user is mentioned to refresh excerpts
+        # Post.where("raw LIKE ?", "%@#{@user.username}%").find_each do |post|
+        #   post.rebake!
+        # end
         render json: success_json.merge(username: user.username)
       else
         render json: failed_json.merge(username: user.username)

--- a/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
+++ b/app/controllers/discourse_plugin_anonymize_user/users_controller.rb
@@ -22,7 +22,7 @@ module DiscoursePluginAnonymizeUser
         sleep(1)
 
         # Rebake all posts where the user is mentioned to refresh excerpts
-        Post.where("raw LIKE ?", "%@#{user.username}%").find_each do |post|
+        Post.where('raw LIKE ?', '%@#{@user.username}%').find_each do |post|
           post.rebake!
         end
         render json: success_json.merge(username: user.username)


### PR DESCRIPTION
Previously, the `excerpts` column of the topic could still contain the original username of the anonymized user. Therefore a rebake is now implemented to make sure any cached content is refreshed.